### PR TITLE
Fix(upload): Resolve iOS image processing failures for menu uploads

### DIFF
--- a/src/lib/i18n/translations.ts
+++ b/src/lib/i18n/translations.ts
@@ -166,6 +166,10 @@ export const translations: Translation = {
     es: "No se ha subido ningún archivo",
     en: "No file uploaded"
   },
+  noImagesProcessed: {
+    es: "No se pudieron procesar imágenes de los archivos subidos.",
+    en: "No images could be processed from the uploaded files."
+  },
   fileUploadSuccess: {
     es: "Archivo subido exitosamente",
     en: "File uploaded successfully"
@@ -225,6 +229,10 @@ export const translations: Translation = {
   edit: {
     es: "Editar",
     en: "Edit"
+  },
+  emptyResponseBody: {
+    es: "Respuesta vacía recibida del servidor.",
+    en: "Received empty response from server."
   },
   dragAndDrop: {
     es: "o arrastrar y soltar",
@@ -470,6 +478,10 @@ export const translations: Translation = {
     en: 'Error during AI processing',
     es: 'Error durante el procesamiento de IA'
   },
+  allFilesFailedProcessing: {
+    es: "Todos los archivos fallaron al procesar. Por favor, inténtalo de nuevo.",
+    en: "All files failed to process. Please try again."
+  },
   errorProcessingImage: {
     en: 'Error processing image',
     es: 'Error al procesar la imagen'
@@ -481,6 +493,10 @@ export const translations: Translation = {
   errorProcessingPdf: {
     en: 'Error processing PDF file',
     es: 'Error al procesar el archivo PDF'
+  },
+  errorGeneratingImageDataForPage: {
+    es: "Error al generar imagen para la página",
+    en: "Error generating image data for page"
   },
   warning: {
     en: 'Warning',
@@ -518,5 +534,9 @@ export const translations: Translation = {
   takePhotoOnMobile: {
     es: "Toma una foto",
     en: "Take a picture!"
+  },
+  tooManyPdfPageErrors: {
+    es: "Demasiadas páginas del PDF fallaron al procesar. Por favor, revisa el archivo.",
+    en: "Too many PDF pages failed to process. Please check the file."
   }
 }; 


### PR DESCRIPTION
This commit addresses an issue where menu image processing was failing on iOS devices (Safari and Chrome), resulting in no data being written to the database. The core problem likely stemmed from client-side image conversion and handling, particularly with `canvas.toDataURL()` on iOS.

Key changes include:

1.  **Enhanced Client-Side Image Robustness (`MenuUploader.svelte`):**
    *   Added explicit checks for `null` or short `dataURL` outputs from `canvas.toDataURL()` in both PDF page processing and general image compression. Problematic pages/images are now skipped with user notification.
    *   Added checks for zero-dimension images in `compressImage` to detect corrupted image loads.
    *   Added console logging for `dataURL` lengths to aid in debugging.

2.  **Refined Image Compression Parameters (`MenuUploader.svelte`):**
    *   Reduced `IMAGE_QUALITY` for PNGs from 1.0 to 0.9 to decrease file size while aiming to maintain OCR quality.
    *   Dynamically adjusted `PDF_SCALE_FACTOR` for mobile devices (1.2 vs 1.5 for desktop) to reduce initial canvas sizes for PDF pages on mobile.

3.  **Improved Error Handling and User Feedback (`MenuUploader.svelte`):**
    *   Implemented tracking for failed PDF page processing. If more than half of a PDF's pages fail, the upload for that PDF is aborted with a user notification.
    *   Implemented tracking for general file processing failures. If all selected files fail processing, the entire upload operation is aborted with a user notification.
    *   Ensured `generateRestaurantData` is not called if no valid images are produced.
    *   Improved handling of non-OK HTTP responses from the `/api/process-images` endpoint, ensuring server errors are clearly displayed to you.

4.  **Added New Translations:**
    *   Added i18n keys for new error messages:
        *   `errorGeneratingImageDataForPage`
        *   `tooManyPdfPageErrors`
        *   `allFilesFailedProcessing`
        *   `noImagesProcessed`
        *   `emptyResponseBody`

These changes aim to make the image uploading and processing pipeline more resilient and provide better feedback to you, especially on iOS devices.